### PR TITLE
[AI - #59] 날짜가 지난 전시회를 추천하지 않도록 수정

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -100,7 +100,8 @@ def process_exhibition(location, free_time):
         # image url을 추가
         full_data["image"] = image
 
-        event_list.append(full_data)
+        if is_free_time_in_period(free_time, full_data['period']):
+            event_list.append(full_data)
 
     return {"code": "SU", "message": "Success.", "result": event_list}
 


### PR DESCRIPTION
## 🛰️ Issue Number
#59 
## 🪐 작업 내용
process_popupstore와 동일하게 is_free_time_in_period 함수를 사용하여 날짜가 지난 전시회를 event_list에 추가하지 않도록 수정.
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
